### PR TITLE
New tag for F2Pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -143,7 +143,6 @@
         "七彩神仙鱼" : {
             "name" : "F2Pool",
             "link" : "https://www.f2pool.com/"
-        }
         },
         "🐟" : {
             "name" : "F2Pool",

--- a/pools.json
+++ b/pools.json
@@ -143,6 +143,11 @@
         "七彩神仙鱼" : {
             "name" : "F2Pool",
             "link" : "https://www.f2pool.com/"
+        }
+        },
+        "🐟" : {
+            "name" : "F2Pool",
+            "link" : "https://www.f2pool.com/"
         },
         "HHTT" : {
             "name" : "HHTT",
@@ -346,7 +351,7 @@
         },
         "/DCEX/" : {
             "name" : "DCEX",
-            "link" : "http://dcexploration.cn"               
+            "link" : "http://dcexploration.cn"
         },
         "/BTPOOL/" : {
             "name" : "BTPOOL",


### PR DESCRIPTION
F2Pool no longer seem to use `七彩神仙鱼` to tag block rewards anymore. Instead they use the fish symbol `🐟` (F2Pool was previously known as `Discus Fish`). 

See the [blocks on Blockchair](https://blockchair.com/bitcoin/blocks?q=guessed_miner(F2Pool)#).