### PR TITLE
Add OwnBlock mining pool

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -596,6 +596,11 @@
             "name" : "BitFuFuPool",
             "link" : "https://www.bitfufu.com/pool"
         }
+,
+        "/ownblock/": {
+            "name": "OwnBlock",
+            "link": "https://ownblock.io"
+        }
     },
     "payout_addresses" : {
         "1MkCDCzHpBsYQivp8MxjY5AkTGG1f2baoe": {


### PR DESCRIPTION
Adds OwnBlock (https://ownblock.io), a cryptocurrency mining pool supporting Bitcoin Cash, Bitcoin and Monero.

Coinbase tag: `/ownblock/`

Block: 952870